### PR TITLE
Convert RGBA format (from the tag data) to AARRGGBB format

### DIFF
--- a/app/src/main/java/com/bscan/ui/components/ColorPreviewCard.kt
+++ b/app/src/main/java/com/bscan/ui/components/ColorPreviewCard.kt
@@ -56,9 +56,31 @@ fun ColorPreviewCard(
 
 private fun parseColor(colorHex: String): Color {
     return try {
-        val cleanHex = colorHex.removePrefix("#").padEnd(8, 'F')
-        val colorInt = cleanHex.toLong(16)
-        Color(colorInt)
+        val cleanHex = colorHex.removePrefix("#")
+        
+        // Handle different hex formats
+        val colorLong = when (cleanHex.length) {
+            6 -> {
+                // RGB format - add full alpha
+                ("FF" + cleanHex).toLong(16)
+            }
+            8 -> {
+                // Check if this is RGBA or AARRGGBB format
+                // If it looks like RGBA (common from tag data), convert to AARRGGBB
+                val r = cleanHex.substring(0, 2)
+                val g = cleanHex.substring(2, 4)
+                val b = cleanHex.substring(4, 6)
+                val a = cleanHex.substring(6, 8)
+                // Convert RGBA to AARRGGBB for Android
+                (a + r + g + b).toLong(16)
+            }
+            else -> {
+                // Default to gray
+                0xFFAAAAAA
+            }
+        }
+        
+        Color(colorLong)
     } catch (e: Exception) {
         Color.Gray
     }

--- a/app/src/main/java/com/bscan/ui/components/ColorPreviewCard.kt
+++ b/app/src/main/java/com/bscan/ui/components/ColorPreviewCard.kt
@@ -45,7 +45,7 @@ fun ColorPreviewCard(
                     fontWeight = FontWeight.Medium
                 )
                 Text(
-                    text = "#${colorHex.take(6)}",
+                    text = "#${colorHex.removePrefix("#").take(6)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/bscan/utils/BambuTagDecoder.kt
+++ b/app/src/main/java/com/bscan/utils/BambuTagDecoder.kt
@@ -74,7 +74,17 @@ object BambuTagDecoder {
     
     private fun extractColorName(bytes: ByteArray): String {
         val colorHex = extractColorHex(bytes)
-        // Simple color name mapping based on hex values
+        
+        // Check alpha channel (last 2 characters in RGBA format)
+        if (colorHex.length >= 8) {
+            val alpha = colorHex.takeLast(2).lowercase()
+            if (alpha == "00") {
+                return "Clear/Transparent"
+            }
+            // Warning: I do not have a nonclear transparent filament to test behaviour.
+        }
+        
+        // Simple color name mapping based on RGB values (first 6 chars)
         return when (colorHex.take(6).lowercase()) {
             "ff0000" -> "Red"
             "00ff00" -> "Green"


### PR DESCRIPTION
> Includes changes from #1 

Summary

  - Fix color preview dot display in FilamentDetailsScreen
  - Convert RGBA color format from NFC tags to Android's AARRGGBB format
  - Improve detection of translucent filaments
  - Resolve padding issue on hex colour code in filament detail view

  Changes

  - Updated parseColor() function in ColorPreviewCard.kt to properly handle RGBA → AARRGGBB conversion
  - Added format detection for 6-char (RGB) and 8-char (RGBA) hex strings
  - Ensures color preview dot displays correct colors from Bambu NFC tag data